### PR TITLE
fix: resolve ESLint build errors

### DIFF
--- a/REPORT_BUILD.md
+++ b/REPORT_BUILD.md
@@ -1,0 +1,5 @@
+# Build Report
+
+- Escaped apostrophes in JSX in `app/admin/flags/page.tsx`, `app/page.tsx`, and `components/error-boundary.tsx`.
+- Replaced explicit `any` with `Record<string, unknown>` in `app/qa/whoami/page.tsx`.
+- ESLint remains enabled; no changes to database or environment variables were made.

--- a/app/admin/flags/page.tsx
+++ b/app/admin/flags/page.tsx
@@ -177,7 +177,7 @@ export default function FeatureFlagsPage() {
                     <SelectValue placeholder="Seleziona ambito" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="global">Globale (tutta l'organizzazione)</SelectItem>
+                    <SelectItem value="global">Globale (tutta l&apos;organizzazione)</SelectItem>
                     <SelectItem value="location">Per Location</SelectItem>
                   </SelectContent>
                 </Select>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -99,7 +99,7 @@ export default function HomePage() {
               <div>
                 <p className="font-medium">Contesto non impostato</p>
                 <p className="text-sm text-muted-foreground">
-                  Seleziona un'organizzazione e una location per accedere alle funzionalità complete.
+                  Seleziona un&apos;organizzazione e una location per accedere alle funzionalità complete.
                 </p>
               </div>
             </div>

--- a/app/qa/whoami/page.tsx
+++ b/app/qa/whoami/page.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { supabase } from '@/lib/supabase/client';
 
 export default function WhoAmI() {
-  const [state, setState] = useState<any>({});
+  const [state, setState] = useState<Record<string, unknown>>({});
   useEffect(() => {
     (async () => {
       const { data: { user } } = await supabase.auth.getUser();

--- a/components/error-boundary.tsx
+++ b/components/error-boundary.tsx
@@ -48,7 +48,7 @@ function DefaultErrorFallback({ error }: { error?: Error }) {
           </div>
           <div className="ml-3">
             <h3 className="text-sm font-medium text-gray-800">
-              Errore dell'applicazione
+              Errore dell&apos;applicazione
             </h3>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- escape apostrophes in JSX to satisfy `react/no-unescaped-entities`
- replace explicit `any` with `Record<string, unknown>` in whoami page
- add build report

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*
- `npm run test:smoke` *(fails: Missing API key. Pass it to the constructor `new Resend("re_123")`)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e116b8f4832a960542ef07907e34