### PR TITLE
fix: handle Supabase join arrays in permissions helper

### DIFF
--- a/REPORT_PERMISSIONS_FIX.md
+++ b/REPORT_PERMISSIONS_FIX.md
@@ -1,5 +1,3 @@
-## Permissions fix
-
-- **Causa:** la query `user_roles` restituisce `roles` come array; il loop precedente presupponeva un oggetto.
-- **Fix:** iterazione annidata `roles[] -> role_permissions[]` con tipi minimi per rispettare la shape.
-- **Impatto DB:** nessuno.
+Causa: join Supabase restituiscono oggetti o array.
+Soluzione: helper asArray per iterare roles, role_permissions e override permissions.
+Impatto: nessuna modifica funzionale.


### PR DESCRIPTION
## Summary
- ensure roles, role_permissions and overrides handle object or array shapes
- add asArray helper and minimal types for Supabase join results
- document permissions fix

## Testing
- `npx tsc --noEmit lib/permissions.ts --target ES2017 --moduleResolution bundler --module esnext --lib dom,dom.iterable,esnext --types node --skipLibCheck`
- `npm run lint` *(warnings: PermissionRow unused, location_id unused)*
- `npm run test:smoke` *(fails: Missing API key)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e4c50f44832aaf77b68ec9955b22