### PR TITLE
fix: update supabase cookie handling

### DIFF
--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -9,20 +9,24 @@ export async function updateSession(request: NextRequest) {
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        get: (name) => request.cookies.get(name)?.value,
-        set: (name, value, options) => {
-          request.cookies.set({ name, value, ...options });
-          response.cookies.set({ name, value, ...options });
+        get: (name: string) => request.cookies.get(name)?.value,
+        set: (name: string, value: string, options?: any) => {
+          // aggiorna SIA la response (browser) SIA la request (Server Components)
+          response.cookies.set(name, value, options);
+          request.cookies.set(name, value, options);
         },
-        remove: (name, options) => {
-          request.cookies.delete({ name, ...options });
-          response.cookies.delete({ name, ...options });
+        remove: (name: string, options?: any) => {
+          // NextRequest.delete accetta solo (name)
+          request.cookies.delete(name);
+          // NextResponse.delete accetta (name, options?)
+          response.cookies.delete(name, options);
         },
       },
     }
   );
 
-  // forza refresh se necessario
+  // forza un getUser() per gestire il refresh token/cookie
   await supabase.auth.getUser();
+
   return response;
 }


### PR DESCRIPTION
## Summary
- fix Supabase middleware cookie handling for Next 15

## Testing
- `npx vercel --version` *(fails: 403 Forbidden to registry.npmjs.org/vercel)*
- `npm run build` *(fails: Module not found: Can't resolve '@supabase/ssr')*
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org/@supabase/ssr)*

------
https://chatgpt.com/codex/tasks/task_e_68b5028234bc832aafa2a6deedd94bcc