### PR TITLE
fix: update supabase middleware cookie handling

### DIFF
--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -11,21 +11,21 @@ export async function updateSession(request: NextRequest) {
       cookies: {
         get: (name: string) => request.cookies.get(name)?.value,
         set: (name: string, value: string, options?: any) => {
-          // aggiorna SIA la response (browser) SIA la request (Server Components)
+          // response può ricevere options; request NO (solo name, value)
           response.cookies.set(name, value, options);
-          request.cookies.set(name, value, options);
+          request.cookies.set(name, value);
         },
         remove: (name: string, options?: any) => {
-          // NextRequest.delete accetta solo (name)
+          // request.delete: solo (name)
           request.cookies.delete(name);
-          // NextResponse.delete accetta (name, options?)
+          // response.delete: (name, options?) — le options sono opzionali
           response.cookies.delete(name, options);
         },
       },
     }
   );
 
-  // forza un getUser() per gestire il refresh token/cookie
+  // Forza refresh token/cookie se necessario
   await supabase.auth.getUser();
 
   return response;


### PR DESCRIPTION
## Summary
- handle cookies with proper NextRequest/NextResponse signatures

## Testing
- `npx tsc --noEmit utils/supabase/middleware.ts --module esnext --moduleResolution bundler --target ES2022 --lib dom,dom.iterable,es2022 --skipLibCheck --esModuleInterop` *(fails: Cannot find module '@supabase/ssr')*
- `npm run lint`
- `npm run test:smoke` *(fails: Missing API key for Resend)*

------
https://chatgpt.com/codex/tasks/task_e_68b503de898c832ab41b801f4425cd86