### PR TITLE
fix: adjust supabase middleware cookie deletion for Next 15

### DIFF
--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -11,21 +11,18 @@ export async function updateSession(request: NextRequest) {
       cookies: {
         get: (name: string) => request.cookies.get(name)?.value,
         set: (name: string, value: string, options?: any) => {
-          // response può ricevere options; request NO (solo name, value)
+          // response accetta options; request NO
           response.cookies.set(name, value, options);
           request.cookies.set(name, value);
         },
-        remove: (name: string, options?: any) => {
-          // request.delete: solo (name)
+        remove: (name: string) => {
           request.cookies.delete(name);
-          // response.delete: (name, options?) — le options sono opzionali
-          response.cookies.delete(name, options);
+          response.cookies.delete(name);
         },
       },
     }
   );
 
-  // Forza refresh token/cookie se necessario
   await supabase.auth.getUser();
 
   return response;


### PR DESCRIPTION
## Summary
- update Supabase middleware cookie removal to use single-argument API for Next 15
- simplify cookie comments to note options only on response

## Testing
- `npm run lint` *(fails: Failed to patch ESLint because the calling module was not recognized)*
- `npx vercel build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*
- `npm run test:smoke` *(fails: Missing API key. Pass it to the constructor `new Resend("re_123")`)*

------
https://chatgpt.com/codex/tasks/task_e_68b5053e8300832a837ed1f000cc7d08