### PR TITLE
refactor: align Supabase SSR cookie API with v0.5.x

### DIFF
--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -1,14 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServerClient } from "@supabase/ssr";
 
-// Tip opzionale per le options accettate da ResponseCookies.delete({ ... })
-type CookieDeleteOptions = Partial<{
+// Tip larghe per le options di set/delete (compatibili con CookieSerializeOptions)
+type CookieOpts = Partial<{
   path: string;
   domain: string;
   secure: boolean;
   httpOnly: boolean;
-  sameSite: "lax" | "strict" | "none";
-  // maxAge e expires non sono rilevanti per delete, ma non danno fastidio se presenti
+  sameSite: boolean | "lax" | "strict" | "none";
   maxAge: number;
 }>;
 
@@ -20,17 +19,19 @@ export async function updateSession(request: NextRequest) {
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        get: (name: string) => request.cookies.get(name)?.value,
-        set: (name: string, value: string, options?: any) => {
-          // response può ricevere options; request NO (solo name, value)
+        // ✅ CookieMethodsServer vuole getAll()
+        getAll: () =>
+          request.cookies.getAll().map((c) => ({ name: c.name, value: c.value })),
+
+        // ✅ request.set(name, value) (no options) • response.set(name, value, options?)
+        set: (name: string, value: string, options?: CookieOpts) => {
           response.cookies.set(name, value, options);
           request.cookies.set(name, value);
         },
-        // ⬇️ conserva le options su Response.delete usando la forma a oggetto
-        remove: (name: string, options?: CookieDeleteOptions) => {
-          // NextRequest.delete: solo (name)
+
+        // ✅ request.delete(name) • response.delete({ name, ...options? })
+        remove: (name: string, options?: CookieOpts) => {
           request.cookies.delete(name);
-          // NextResponse.delete: (name) | ({ name, ...options })
           if (options && Object.keys(options).length > 0) {
             response.cookies.delete({ name, ...options });
           } else {
@@ -41,8 +42,9 @@ export async function updateSession(request: NextRequest) {
     }
   );
 
-  // Innesca eventuale refresh token/cookie
+  // Innesca refresh session/cookie se necessario
   await supabase.auth.getUser();
+
   return response;
 }
 

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -9,9 +9,13 @@ export function createClient() {
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        get(name: string) { return cookieStore.get(name)?.value; },
-        set() { /* no-op: scrive la middleware */ },
-        remove(_name: string, _options?: unknown) { /* no-op: scrive la middleware */ },
+        // ✅ fornisci getAll() come richiesto dal tipo CookieMethodsServer
+        getAll: () =>
+          cookieStore.getAll().map((c) => ({ name: c.name, value: c.value })),
+
+        // 🚫 niente scrittura cookie qui: la fa la middleware
+        set: () => {},
+        remove: () => {},
       },
     }
   );


### PR DESCRIPTION
## Summary
- replace middleware client to use `getAll` and object-based cookie deletion
- expose `getAll` and no-op methods on server-side Supabase client

## Testing
- `npx vercel build` *(fails: 403 Forbidden fetching vercel package)*
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*
- `npm run lint` *(fails: Failed to patch ESLint)*
- `npm run test:smoke` *(fails: Missing API key)*

------
https://chatgpt.com/codex/tasks/task_e_68b509244ee8832a8fb0aa42f4115142