### PR TITLE
chore: update supabase SSR integration

### DIFF
--- a/app/api/v1/me/permissions/route.ts
+++ b/app/api/v1/me/permissions/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@/utils/supabase/server";
+import { supabaseServer } from "@/utils/supabase/server";
 import { supabaseAdmin } from "@/lib/supabase/server";
 
 export async function GET(req: Request) {
@@ -9,7 +9,7 @@ export async function GET(req: Request) {
     const locationId = url.searchParams.get("locationId") ?? "";
 
     // 1) Auth utente via @supabase/ssr (server-side)
-    const sb = await createClient();
+    const sb = await supabaseServer();
     const { data: { user }, error: authErr } = await sb.auth.getUser();
     if (authErr || !user) {
       return NextResponse.json({}, { status: 401 });

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,12 +1,1 @@
-import type { NextRequest } from "next/server";
-import { updateSession } from "@/utils/supabase/middleware";
-
-export async function middleware(request: NextRequest) {
-  return updateSession(request);
-}
-
-export const config = {
-  matcher: [
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
-  ],
-};
+export { middleware, config } from "@/utils/supabase/middleware";

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -1,50 +1,29 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServerClient } from "@supabase/ssr";
 
-// Tip larghe per le options di set/delete (compatibili con CookieSerializeOptions)
-type CookieOpts = Partial<{
-  path: string;
-  domain: string;
-  secure: boolean;
-  httpOnly: boolean;
-  sameSite: boolean | "lax" | "strict" | "none";
-  maxAge: number;
-}>;
-
-export async function updateSession(request: NextRequest) {
-  const response = NextResponse.next();
-
+export async function middleware(request: NextRequest) {
+  const response = NextResponse.next({ request });
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        // ✅ CookieMethodsServer vuole getAll()
-        getAll: () =>
-          request.cookies.getAll().map((c) => ({ name: c.name, value: c.value })),
-
-        // ✅ request.set(name, value) (no options) • response.set(name, value, options?)
-        set: (name: string, value: string, options?: CookieOpts) => {
-          response.cookies.set(name, value, options);
-          request.cookies.set(name, value);
-        },
-
-        // ✅ request.delete(name) • response.delete({ name, ...options? })
-        remove: (name: string, options?: CookieOpts) => {
-          request.cookies.delete(name);
-          if (options && Object.keys(options).length > 0) {
-            response.cookies.delete({ name, ...options });
-          } else {
-            response.cookies.delete(name);
-          }
+        getAll() { return request.cookies.getAll(); },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            response.cookies.set(name, value, options);
+          });
         },
       },
     }
   );
-
-  // Innesca refresh session/cookie se necessario
   await supabase.auth.getUser();
-
   return response;
 }
+
+export const config = {
+  matcher: [
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+  ],
+};
 

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,21 +1,21 @@
 import { cookies } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
 
-export function createClient() {
-  const cookieStore = cookies();
-
+export async function supabaseServer() {
+  const cookieStore = await cookies();
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        // ✅ fornisci getAll() come richiesto dal tipo CookieMethodsServer
-        getAll: () =>
-          cookieStore.getAll().map((c) => ({ name: c.name, value: c.value })),
-
-        // 🚫 niente scrittura cookie qui: la fa la middleware
-        set: () => {},
-        remove: () => {},
+        getAll() { return cookieStore.getAll(); },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) => {
+              cookieStore.set(name, value, options);
+            });
+          } catch { /* noop for RSC */ }
+        },
       },
     }
   );


### PR DESCRIPTION
## Summary
- replace middleware with `@supabase/ssr` v0.5 cookie helpers
- expose new `supabaseServer` helper and migrate API usage
- re-export middleware entrypoint

## Testing
- `bun run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b50bf58af4832aadb44a53803b6350