### PR TITLE
feat: sync Supabase cookies and add not-found page

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from "react";
+import Link from "next/link";
+import { NotFoundExtras } from "@/components/not-found-client";
+
+export default function NotFound() {
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-16">
+      <h1 className="text-2xl font-semibold">Pagina non trovata</h1>
+      <p className="mt-2 text-muted-foreground">La risorsa non esiste o è stata spostata.</p>
+      <Suspense fallback={null}>
+        <NotFoundExtras />
+      </Suspense>
+      <div className="mt-6">
+        <Link href="/" className="underline">Torna alla home</Link>
+      </div>
+    </main>
+  );
+}

--- a/components/not-found-client.tsx
+++ b/components/not-found-client.tsx
@@ -1,0 +1,9 @@
+"use client";
+import { useSearchParams } from "next/navigation";
+
+export function NotFoundExtras() {
+  const sp = useSearchParams();
+  const reason = sp.get("reason");
+  if (!reason) return null;
+  return <p className="mt-3 text-sm text-muted-foreground">Dettagli: {reason}</p>;
+}

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -1,29 +1,64 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createServerClient } from "@supabase/ssr";
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
 
+/**
+ * Middleware SSR:
+ * - @supabase/ssr v0.5.x richiede cookies.getAll()/setAll()
+ * - In setAll scriviamo SEMPRE su response.cookies (con options) e
+ *   manteniamo lo stato anche su request.cookies per la stessa richiesta.
+ */
 export async function middleware(request: NextRequest) {
+  // Passa la request a NextResponse.next per preservare body/headers stream
   const response = NextResponse.next({ request });
+
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        getAll() { return request.cookies.getAll(); },
-        setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value, options }) => {
+        // Legge tutti i cookie disponibili nella richiesta corrente
+        getAll() {
+          return request.cookies.getAll().map(c => ({ name: c.name, value: c.value }));
+        },
+
+        /**
+         * Imposta/cancella i cookie richiesti da Supabase.
+         * - Scrive sulla response con le options (path, domain, sameSite, ecc.)
+         * - Mantiene in sync anche request.cookies per questa stessa richiesta:
+         *   - se "delete" (maxAge: 0 / expires passato / value === ""), usa request.cookies.delete(name)
+         *   - altrimenti request.cookies.set(name, value)
+         */
+        setAll(cookiesToSet: { name: string; value: string; options?: CookieOptions }[]) {
+          for (const { name, value, options } of cookiesToSet) {
+            // 1) Scrivi sulla response con le opzioni così come fornite da Supabase
             response.cookies.set(name, value, options);
-          });
+
+            // 2) Mantieni la request allineata per il resto della pipeline di questa richiesta
+            const isDeletion =
+              value === "" ||
+              options?.maxAge === 0 ||
+              (options?.expires && new Date(options.expires).getTime() <= Date.now());
+
+            if (isDeletion) {
+              request.cookies.delete(name);     // Next 15: solo (name)
+            } else {
+              request.cookies.set(name, value); // Next 15: solo (name, value) senza options
+            }
+          }
         },
       },
     }
   );
+
+  // Forza la sincronizzazione (refresh token/cookie) se necessario
   await supabase.auth.getUser();
+
   return response;
 }
 
+// Mantieni il matcher del progetto se diverso
 export const config = {
   matcher: [
     '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
 };
-

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,23 +1,26 @@
 import { cookies } from "next/headers";
-import { createServerClient } from "@supabase/ssr";
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
 
+/**
+ * Client server-side per RSC/route handlers:
+ * - getAll fornisce i cookie correnti
+ * - setAll è no-op (la scrittura effettiva la fa la middleware)
+ */
 export async function supabaseServer() {
   const cookieStore = await cookies();
+
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        getAll() { return cookieStore.getAll(); },
-        setAll(cookiesToSet) {
-          try {
-            cookiesToSet.forEach(({ name, value, options }) => {
-              cookieStore.set(name, value, options);
-            });
-          } catch { /* noop for RSC */ }
+        getAll() {
+          return cookieStore.getAll().map(c => ({ name: c.name, value: c.value }));
+        },
+        setAll(_cookies: { name: string; value: string; options?: CookieOptions }[]) {
+          // no-op in RSC/route handlers: la scrittura è demandata alla middleware
         },
       },
     }
   );
 }
-


### PR DESCRIPTION
## Summary
- sync Supabase middleware cookies with request and response
- make server-side supabase client cookie writes a no-op
- add Suspense-based not-found page with client extras component

## Testing
- `bun run build` *(fails: Failed to fetch `Inter` from Google Fonts)*
- `bun run test:smoke` *(fails: Missing API key for Resend)*
- `bun run lint` *(fails: Failed to patch ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68b50f233678832a99303ea4c8fe4b66