### PR TITLE
chore(permissions): standardize to english-only codes

### DIFF
--- a/REPORT_FINALE.md
+++ b/REPORT_FINALE.md
@@ -38,8 +38,9 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
 - `users` - Utenti (extends auth.users)
 - `users_locations` - Relazioni utente-location (unique constraint)
 
+
 **Sistema Permessi:**
-- `modules` - 9 moduli (locations, inventario, tecnici, incidents, fornitori, ordini, task, chat, api)
+- `modules` - 9 moduli (locations, inventory, technicians, incidents, suppliers, orders, tasks, chat, api)
 - `actions` - 9 azioni (view, create, edit, delete, send_order, approve, manage_users, manage_permissions, manage_flags)
 - `permissions` - ~25 permessi (formato modulo.azione)
 - `roles` - Ruoli per organizzazione (admin, manager, staff)
@@ -48,7 +49,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
 - `user_permission_overrides` - Override individuali
 
 **Governance:**
-- `permission_presets` - 4 preset (admin_full, manager_standard, staff_cucina, staff_sala)
+- `permission_presets` - 4 preset (admin_full, manager_standard, staff_kitchen, staff_dining)
 - `preset_permissions` - Relazioni preset-permessi
 - `feature_flags` - Flags per modulo/location
 - `audit_log` - Log modifiche con diff JSON
@@ -116,18 +117,18 @@ $$;
 **Ruoli:**
 - admin (tutte le permissions)
 - manager (view/create/edit/approve, no delete)
-- staff (view limitato, create task/chat)
+- staff (view limitato, create tasks/chat)
 
 **Permission Presets:**
 - admin_full (25 permessi)
 - manager_standard (15 permessi)
-- staff_cucina (6 permessi)
-- staff_sala (5 permessi)
+- staff_kitchen (6 permessi)
+- staff_dining (5 permessi)
 
 **Feature Flags:**
-- ordini.auto_approval (globale, disattivo)
+- orders.auto_approval (globale, disattivo)
 - chat.real_time (globale, attivo)
-- inventario.advanced_tracking (Lyon: attivo, Menton: disattivo)
+- inventory.advanced_tracking (Lyon: attivo, Menton: disattivo)
 
 ---
 

--- a/app/admin/flags/page.tsx
+++ b/app/admin/flags/page.tsx
@@ -19,7 +19,7 @@ import { useRequireSession } from '@/lib/useRequireSession'
 const mockFlags = [
   {
     id: '1',
-    module_code: 'ordini',
+    module_code: 'orders',
     flag_code: 'auto_approval',
     name: 'Auto Approval Ordini',
     description: 'Approva automaticamente gli ordini sotto una certa soglia',
@@ -41,7 +41,7 @@ const mockFlags = [
   },
   {
     id: '3',
-    module_code: 'inventario',
+    module_code: 'inventory',
     flag_code: 'advanced_tracking',
     name: 'Tracking Avanzato',
     description: 'Sistema di tracciamento avanzato per inventario',
@@ -52,7 +52,7 @@ const mockFlags = [
   },
   {
     id: '4',
-    module_code: 'inventario',
+    module_code: 'inventory',
     flag_code: 'advanced_tracking',
     name: 'Tracking Avanzato',
     description: 'Sistema di tracciamento avanzato per inventario',
@@ -64,7 +64,7 @@ const mockFlags = [
 ]
 
 const mockModules = [
-  'locations', 'inventario', 'tecnici', 'incidents', 'fornitori', 'ordini', 'task', 'chat', 'api'
+  'locations', 'inventory', 'technicians', 'incidents', 'suppliers', 'orders', 'tasks', 'chat', 'api'
 ]
 
 export default function FeatureFlagsPage() {

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -19,21 +19,21 @@ const mockUsers = [
     email: 'admin@demo.com',
     roles: ['admin'],
     locations: ['Lyon', 'Menton'],
-    permissions: ['locations.manage_users', 'locations.manage_permissions', 'ordini.send_order']
+    permissions: ['locations.manage_users', 'locations.manage_permissions', 'orders.send_order']
   },
   {
     id: '2', 
     email: 'manager@demo.com',
     roles: ['manager'],
     locations: ['Lyon'],
-    permissions: ['ordini.approve', 'inventario.edit']
+    permissions: ['orders.approve', 'inventory.edit']
   },
   {
     id: '3',
     email: 'staff@demo.com', 
     roles: ['staff'],
     locations: ['Lyon'],
-    permissions: ['task.create', 'chat.create']
+    permissions: ['tasks.create', 'chat.create']
   }
 ]
 
@@ -46,9 +46,9 @@ const mockRoles = [
 const mockPermissions = [
   'locations.view', 'locations.create', 'locations.edit', 'locations.delete',
   'locations.manage_users', 'locations.manage_permissions',
-  'inventario.view', 'inventario.create', 'inventario.edit',
-  'ordini.view', 'ordini.create', 'ordini.edit', 'ordini.send_order', 'ordini.approve',
-  'task.view', 'task.create', 'task.edit',
+  'inventory.view', 'inventory.create', 'inventory.edit',
+  'orders.view', 'orders.create', 'orders.edit', 'orders.send_order', 'orders.approve',
+  'tasks.view', 'tasks.create', 'tasks.edit',
   'chat.view', 'chat.create'
 ]
 

--- a/components/nav/SidebarClient.tsx
+++ b/components/nav/SidebarClient.tsx
@@ -63,13 +63,13 @@ const navigation = [
         name: 'Inventario',
         href: '/inventario',
         icon: Package,
-        permission: 'inventario.view'
+        permission: 'inventory.view'
       },
       {
         name: 'Tecnici',
         href: '/tecnici',
         icon: Wrench,
-        permission: 'tecnici.view'
+        permission: 'technicians.view'
       },
       {
         name: 'Incidents',
@@ -81,19 +81,19 @@ const navigation = [
         name: 'Fornitori',
         href: '/fornitori',
         icon: Truck,
-        permission: 'fornitori.view'
+        permission: 'suppliers.view'
       },
       {
         name: 'Ordini',
         href: '/ordini',
         icon: ShoppingCart,
-        permission: 'ordini.view'
+        permission: 'orders.view'
       },
       {
         name: 'Task',
         href: '/task',
         icon: CheckSquare,
-        permission: 'task.view'
+        permission: 'tasks.view'
       },
       {
         name: 'Chat',

--- a/db/seeds/002_permission_presets.sql
+++ b/db/seeds/002_permission_presets.sql
@@ -8,8 +8,8 @@
 INSERT INTO permission_presets (id, code, name) VALUES
     ('60000000-0000-0000-0000-000000000001', 'admin_full', 'Admin Full'),
     ('60000000-0000-0000-0000-000000000002', 'manager_standard', 'Manager Standard'),
-    ('60000000-0000-0000-0000-000000000003', 'staff_cucina', 'Staff Cucina'),
-    ('60000000-0000-0000-0000-000000000004', 'staff_sala', 'Staff Sala')
+    ('60000000-0000-0000-0000-000000000003', 'staff_kitchen', 'Staff Kitchen'),
+    ('60000000-0000-0000-0000-000000000004', 'staff_dining', 'Staff Dining')
 ON CONFLICT (code) DO NOTHING;
 
 -- =====================================================
@@ -41,14 +41,14 @@ INSERT INTO permission_preset_items (preset_id, permission_id, allow) VALUES
     ('60000000-0000-0000-0000-000000000002', '30000000-0000-0000-0000-000000000008', true)
 ON CONFLICT (preset_id, permission_id) DO NOTHING;
 
--- Staff Cucina subset
+-- Staff Kitchen subset
 INSERT INTO permission_preset_items (preset_id, permission_id, allow) VALUES
     ('60000000-0000-0000-0000-000000000003', '30000000-0000-0000-0000-000000000001', true),
     ('60000000-0000-0000-0000-000000000003', '30000000-0000-0000-0000-000000000003', true),
     ('60000000-0000-0000-0000-000000000003', '30000000-0000-0000-0000-000000000008', true)
 ON CONFLICT (preset_id, permission_id) DO NOTHING;
 
--- Staff Sala subset
+-- Staff Dining subset
 INSERT INTO permission_preset_items (preset_id, permission_id, allow) VALUES
     ('60000000-0000-0000-0000-000000000004', '30000000-0000-0000-0000-000000000001', true),
     ('60000000-0000-0000-0000-000000000004', '30000000-0000-0000-0000-000000000003', true)

--- a/lib/permissions-registry.ts
+++ b/lib/permissions-registry.ts
@@ -1,0 +1,35 @@
+export const modules = [
+  'flags',
+  'suppliers',
+  'incidents',
+  'inventory',
+  'locations',
+  'orders',
+  'tasks',
+  'technicians',
+  'users',
+] as const;
+
+export const actions = [
+  'view',
+  'create',
+  'edit',
+  'delete',
+  'manage',
+  'manage_users',
+  'manage_permissions',
+  'manage_flags',
+  'send_order',
+  'approve',
+] as const;
+
+export type Module = typeof modules[number];
+export type Action = typeof actions[number];
+
+export type Permission =
+  | `${Module}.${Action}`
+  | `${Module}:*`
+  | '*'
+  | (string & {});
+
+export const registry = { modules, actions } as const;

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -1,4 +1,5 @@
-export type Permission = string;
+import type { Permission } from './permissions-registry';
+export type { Permission } from './permissions-registry';
 
 export function can(perms: Permission[] | undefined, needed: Permission | Permission[]): boolean {
   if (!perms?.length) return false;

--- a/tests/rls-permissions.ts
+++ b/tests/rls-permissions.ts
@@ -95,7 +95,7 @@ async function testPermissionSystem(): Promise<TestResult> {
     }
     
     // Test that admin can send orders
-    const canSendOrder = await can(adminUserId, 'ordini.send_order', context)
+    const canSendOrder = await can(adminUserId, 'orders.send_order', context)
     
     // Test that admin can manage users
     const canManageUsers = await can(adminUserId, 'locations.manage_users', context)
@@ -104,10 +104,10 @@ async function testPermissionSystem(): Promise<TestResult> {
     const staffUserId = '550e8400-e29b-41d4-a716-446655440102' // Mock staff user
     
     // Staff should NOT be able to send orders
-    const staffCanSendOrder = await can(staffUserId, 'ordini.send_order', context)
+    const staffCanSendOrder = await can(staffUserId, 'orders.send_order', context)
     
     // Staff should be able to create tasks
-    const staffCanCreateTask = await can(staffUserId, 'task.create', context)
+    const staffCanCreateTask = await can(staffUserId, 'tasks.create', context)
     
     // Validate results
     const issues = []


### PR DESCRIPTION
## Summary
- add central permission registry exporting typed `Permission`
- update permission strings to use english module prefixes
- rename legacy staff presets to `staff_kitchen` and `staff_dining`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b64053f2c8832abe819f024ae2b538